### PR TITLE
Add option for recursive select bindings

### DIFF
--- a/autoload/cutlass.vim
+++ b/autoload/cutlass.vim
@@ -1,5 +1,6 @@
 
 function! cutlass#overrideSelectBindings()
+    let recursive = get(g:, 'CutlassRecursiveSelectBindings', 0)
     let i = 33
 
     " Add a map for every printable character to copy to black hole register
@@ -10,15 +11,15 @@ function! cutlass#overrideSelectBindings()
             if i ==# 92
               let char = '\\'
             endif
-            exec 'snoremap '. char .' <c-o>"_c'. char
+            exec 's' . (recursive ? 'map ' : 'noremap ') . char .' <c-o>"_c' . char
         endif
 
         let i = i + 1
     endwhile
 
-    snoremap <bs> <c-o>"_c
-    snoremap <space> <c-o>"_c<space>
-    snoremap \| <c-o>"_c|
+    exec 's' . (recursive ? 'map' : 'noremap') . ' <bs> <c-o>"_c'
+    exec 's' . (recursive ? 'map' : 'noremap') . ' <space> <c-o>"_c<space>'
+    exec 's' . (recursive ? 'map' : 'noremap') . ' \| <c-o>"_c|'
 endfunction
 
 function! cutlass#hasMapping(mapping, mode)

--- a/autoload/cutlass.vim
+++ b/autoload/cutlass.vim
@@ -1,6 +1,11 @@
 
 function! cutlass#overrideSelectBindings()
     let recursive = get(g:, 'CutlassRecursiveSelectBindings', 0)
+    let map = recursive ? 'map' : 'noremap'
+
+    " Create a non recursive 'change' mapping to avoid recursive problems with 'cn' etc.
+    exec 'snoremap <Plug>(CutlassChange) <c-o>"_c'
+
     let i = 33
 
     " Add a map for every printable character to copy to black hole register
@@ -11,15 +16,15 @@ function! cutlass#overrideSelectBindings()
             if i ==# 92
               let char = '\\'
             endif
-            exec 's' . (recursive ? 'map ' : 'noremap ') . char .' <c-o>"_c' . char
+            exec 's' . map . ' ' . char . ' <Plug>(CutlassChange)' . char
         endif
 
         let i = i + 1
     endwhile
 
-    exec 's' . (recursive ? 'map' : 'noremap') . ' <bs> <c-o>"_c'
-    exec 's' . (recursive ? 'map' : 'noremap') . ' <space> <c-o>"_c<space>'
-    exec 's' . (recursive ? 'map' : 'noremap') . ' \| <c-o>"_c|'
+    exec 's' . map . ' <bs> <Plug>(CutlassChange)'
+    exec 's' . map . ' <space> <Plug>(CutlassChange)<space>'
+    exec 's' . map . ' \| <Plug>(CutlassChange)|'
 endfunction
 
 function! cutlass#hasMapping(mapping, mode)

--- a/doc/cutlass.txt
+++ b/doc/cutlass.txt
@@ -1,39 +1,59 @@
-*cutlass.txt*  Adds a 'cut' operation separate from 'delete'
+*cutlass.txt*                    Adds a 'cut' operation separate from 'delete'
 
 Author:  Steve Vermeulen <http://www.stevevermeulen.com/>
 License: MIT
 
-INTRODUCTION                                    *cutlass*
+==============================================================================
+INTRODUCTION                                                           *cutlass*
 
-Cutlass overrides the delete operations to actually just delete and not affect the current yank.
+Cutlass overrides the delete operations to actually just delete and not affect
+the current yank. It achieves this by overriding the following keys to always
+use the black hole register: |c|, |cc|, |C|, |s|, |S|, |d|, |dd|, |D|, |x|, |X|.
 
-It achieves this by overriding the following keys to always use the black hole register:  |c|, |cc|, |C|, |s|, |S|, |d|, |dd|, |D|, |x|, |X|.  Note that if you have already mapped these keys to something else (like we do below with x) then it will not change it again.
+Note that if you have already mapped these keys to something else (like we do
+below with x) then it will not change it again.
 
-After including this plugin, all of these operations will simply delete and not cut.  However, you will still want to have a key for 'cut', which you can add by including the following to your .vimrc:
-
+After including this plugin, all of these operations will simply delete and
+not cut. However, you will still want to have a key for 'cut', which you can
+add by including the following to your .vimrc:
+>
     nnoremap m d
     xnoremap m d
 
     nnoremap mm dd
     nnoremap M D
+<
+'m' here can be thought of as 'move'.
 
-'m' here can be thought of as 'move'.  Note that you will be shadowing the 'add mark' |m| key if you go with this binding
+Note that you will be shadowing the 'add mark' |m| key if you go with this
+binding.
 
 Or you might want to use the 'x' key instead:
-
+>
     nnoremap x d
     xnoremap x d
 
     nnoremap xx dd
     nnoremap X D
+<
+And then use 'dl' instead of 'x' every time you want to delete a single
+character. You might also consider using 's' with vim-subversive
+(https://github.com/svermeulen/vim-subversive) and then using 'cl' as a
+replacement in the same way.
 
-And then use 'dl' instead of 'x' every time you want to delete a single character.  You might also consider using 's' with vim-subversive (https://github.com/svermeulen/vim-subversive) and then using 'cl' as a replacement in the same way.
+See this article for why we would want to do all this:
+http://vimcasts.org/blog/2013/11/registers-the-good-the-bad-and-the-ugly-parts/
 
-See this article (http://vimcasts.org/blog/2013/11/registers-the-good-the-bad-and-the-ugly-parts/) for why we would want to do all this.  You might also consider installing vim-yoink (https://github.com/svermeulen/vim-yoink) which contains other clipboard related improvements mentioned in this article.
+You might also consider installing `vim-yoink` which contains other clipboard
+related improvements mentioned in this article:
+https://github.com/svermeulen/vim-yoink
 
-Based off of vim-easyclip (https://github.com/svermeulen/vim-easyclip) and also Drew Neil's ideas (https://github.com/nelstrom/vim-cutlass) (as well as the name)
+Based off of vim-easyclip (https://github.com/svermeulen/vim-easyclip) and
+also Drew Neil's ideas (https://github.com/nelstrom/vim-cutlass) (as well as
+the name).
 
-CONFIGURATION                     *cutlass-configuration*
+==============================================================================
+CONFIGURATION                                            *cutlass-configuration*
 
 *g:CutlassRecursiveSelectBindings* (default: `0`)
     Set to `1` to make the keybindings in selection mode recursive. This might
@@ -43,4 +63,5 @@ CONFIGURATION                     *cutlass-configuration*
 *g:CutlassOverrideDefaults* (default: 1)
     Set to `0` if you want to call this manually at a time of your chossing.
 
+------------------------------------------------------------------------------
  vim:tw=78:ts=8:ft=help:norl:

--- a/doc/cutlass.txt
+++ b/doc/cutlass.txt
@@ -33,4 +33,14 @@ See this article (http://vimcasts.org/blog/2013/11/registers-the-good-the-bad-an
 
 Based off of vim-easyclip (https://github.com/svermeulen/vim-easyclip) and also Drew Neil's ideas (https://github.com/nelstrom/vim-cutlass) (as well as the name)
 
+CONFIGURATION                     *cutlass-configuration*
+
+*g:CutlassRecursiveSelectBindings* (default: `0`)
+    Set to `1` to make the keybindings in selection mode recursive. This might
+    be helpful for the usage with "autopair" plugins etc. which otherwise
+    would not trigger.
+
+*g:CutlassOverrideDefaults* (default: 1)
+    Set to `0` if you want to call this manually at a time of your chossing.
+
  vim:tw=78:ts=8:ft=help:norl:

--- a/doc/tags
+++ b/doc/tags
@@ -1,2 +1,4 @@
 cutlass	cutlass.txt	/*cutlass*
+cutlass-configuration	cutlass.txt	/*cutlass-configuration*
 cutlass.txt	cutlass.txt	/*cutlass.txt*
+g:CutlassRecursiveSelectBindings	cutlass.txt	/*g:CutlassRecursiveSelectBindings*


### PR DESCRIPTION
First of all thank you for this plugin :heart: 
It makes the usage of (Neo)Vim a lot easier and predictable for me

One issue that always got me was that during snippet expansion (which usually uses select mode) the initial key press would not trigger any "autopair" style plugin (to automatically insert closing parentheses or matching quotation marks). I saw that this issue could easily be resolved by making the select bindings nested/recursive. 

To not mess around wit the defaults I have implemented this as an opt-in feature.
If you think this is outside the scope for this plugin and you like to keep this minimal I would understand, but I thought maybe this is a use case which others could relate to :slightly_smiling_face: 